### PR TITLE
Improved error handlind for dlfcn

### DIFF
--- a/main.c
+++ b/main.c
@@ -5,9 +5,19 @@
 #include <unistd.h>
 #include <dlfcn.h>
 
-#ifndef __x86_64__
+/*#ifndef __x86_64__
 #   error "Must build for x86_64"
 #endif
+*/
+// Unnecessary - works on ARM64e (M1), with correct fixups (checked in IDA Pro 7.7)
+
+bool assert_perror_dlfcn(int *val, char* fn) {
+    if (val == 0) {
+        perror(fn);
+        return false;
+    }
+    return true;
+}
 
 typedef int (*extract_function)(const char* shared_cache_file_path, const char* extraction_root_path, void (^progress)(unsigned current, unsigned total));
 
@@ -22,18 +32,16 @@ int main(int argc, char* argv[]) {
 
     bundle = dlopen("/usr/lib/dsc_extractor.bundle", RTLD_NOW);
 
-    if (bundle == NULL) {
-        fprintf(stderr, "dsc_extractor.bundle could not be loaded from /usr/lib/\n");
-        return -1;
+
+    if (assert_perror_dlfcn(bundle, "dlopen dsc_extractor") != true) {
+        exit(EXIT_FAILURE);
     }
 
     extract = (extract_function)dlsym(bundle, "dyld_shared_cache_extract_dylibs_progress");
 
-    if (extract == NULL) {
-        fprintf(stderr, "dsc_extractor.bundle did not have dyld_shared_cache_extract_dylibs_progress symbol.\n\nThey must have changed the API and we're not that brave...\n");
-        return 1;
+    if (assert_perror_dlfcn((int *)extract, "dlsym dyld_shared_cache_extract_dylibs_progress") != true) {
+        exit(EXIT_FAILURE);
     }
-
 
     void (^callback)(unsigned current, unsigned total) = ^(unsigned int current, unsigned int total) {
         printf("Progress: %d/%d\n", current, total);
@@ -45,6 +53,9 @@ int main(int argc, char* argv[]) {
         printf("Failed to call extract (error %d)\n", result);
         exit(-1);
     }
+    //What does result return on failure and exit? Might be better to leave well enough alone.
+    //I'm lazy.
+
     printf("Finished!\n");
     return result;
 }


### PR DESCRIPTION
More "robust" error handling akin to how `<dlfcn.h>` functions behave (returns null pointer on error, null pointer constant should always be zero if conforming to specs), removed #ifdef/guard preventing compilation on M1 (fixups and everything work on extracted binaries, checked in IDA 7.7).

Up to you if you prefer this style of error handling or want to go the old route -- this route allows more re usability should the codebase be further expanded.

Anyhow, great work.